### PR TITLE
[AE-158] Use POSIXStorage from lib manager

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -63,7 +63,7 @@ jobs:
             # Install the library from the local path.
             - source-path: ./
             - name: Arduino_USBHostMbed5
-            - source-path: https://github.com/arduino-libraries/Arduino_POSIXStorage
+            - name: Arduino_POSIXStorage
             # Additional library dependencies can be listed here.
             # See: https://github.com/arduino/compile-sketches#libraries
           sketch-paths: |


### PR DESCRIPTION
Since Arduino_POSIXStorage is now added to the library manager, we should be able to use that version in the library. This should go round the issue mentioned in https://github.com/arduino/compile-sketches/issues/167