### PR TITLE
[AE-158] Specify compatible sketches for each `fqbn:`

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -22,6 +22,8 @@ on:
   repository_dispatch:
 
 env:
+  UNIVERSAL_SKETCH_PATHS: |
+        - extra/tests
   SKETCHES_REPORTS_PATH: sketches-reports
   SKETCHES_REPORTS_ARTIFACT_NAME: sketches-reports
 
@@ -47,6 +49,29 @@ jobs:
           - fqbn: arduino:mbed_opta:opta
             platforms: |
               - name: arduino:mbed_opta
+        include:
+          - board:
+            - fqbn: arduino:mbed_portenta:envie_m7
+              additional-sketch-paths: |
+                - examples/SimpleStorageWriteRead
+                - examples/PortentaH7Logger
+                - examples/AdvancedUSBInternalOperations
+                - examples/BackupInternalPartitions
+          - board:
+            - fqbn: arduino:renesas_portenta:portenta_c33
+              additional-sketch-paths: |
+                - examples/SimpleStorageWriteRead
+                - examples/PortentaH7Logger
+                - examples/AdvancedUSBInternalOperations
+                - examples/BackupInternalPartitions
+          - board:
+            - fqbn: arduino:mbed_opta:opta
+              additional-sketch-paths: |
+                - examples/SimpleStorageWriteRead
+                - examples/PortentaH7Logger
+                - examples/AdvancedUSBInternalOperations
+                - examples/BackupInternalPartitions
+
 
 
     steps:
@@ -67,7 +92,8 @@ jobs:
             # Additional library dependencies can be listed here.
             # See: https://github.com/arduino/compile-sketches#libraries
           sketch-paths: |
-            - examples
+            ${{ env.UNIVERSAL_SKETCH_PATHS }}
+            ${{ matrix.additional-sketch-paths }}
           enable-deltas-report: true
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -23,7 +23,7 @@ on:
 
 env:
   UNIVERSAL_SKETCH_PATHS: |
-        - extra/tests
+        - extras/tests
   SKETCHES_REPORTS_PATH: sketches-reports
   SKETCHES_REPORTS_ARTIFACT_NAME: sketches-reports
 

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -61,14 +61,12 @@ jobs:
             - fqbn: arduino:renesas_portenta:portenta_c33
               additional-sketch-paths: |
                 - examples/SimpleStorageWriteRead
-                - examples/PortentaH7Logger
                 - examples/AdvancedUSBInternalOperations
                 - examples/BackupInternalPartitions
           - board:
             - fqbn: arduino:mbed_opta:opta
               additional-sketch-paths: |
                 - examples/SimpleStorageWriteRead
-                - examples/PortentaH7Logger
                 - examples/AdvancedUSBInternalOperations
                 - examples/BackupInternalPartitions
 


### PR DESCRIPTION
Due to differences in architecture and physical implementation (e.g. no SD slot on the Opta) not all examples in this library are supposed to work with all architectures. In this PR, we use the following scheme to define for which `fqbn:` which examples should be checked.
```
include:
  - board:
    additional-sketch-path: |
      - example/SketchA
      - example/SketchB
```

We define a `UNIVERSAL_SKETCH_PATH` that includes the location of the test sketches in `extras/tests`. These tests should work for all platforms. `matrix.additional-sketch-paths` references the sketches for each fqbn.