### PR TITLE
[AE-158] Make readme more user-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The Arduino_UnifiedStorage library provides a unified interface to access differ
 * Format partitions and drives (FAT and LittleFS)
 
 ## Compatibility
-This library is compatible with STM32 and Renesas based Arduino boards. The availability of storage mediums depends on the hardware interfaces:
+This library has been tested with the following STM32 and Renesas based Arduino boards. The availability of storage mediums depends on the hardware interfaces:
 * Portenta Machine Control: USB and Internal QSPI Flash
 * Portenta H7 + Portenta Breakout: USB, SD, and QSPI
 * Portenta H7 + Vision Shield: SD and QSPI

--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ This library has been tested with the following STM32 and Renesas based Arduino 
 * Portenta H7 + Vision Shield: SD and QSPI
 * Portenta C33 + Portenta Breakout: USB, SD, and QSPI
 * Portenta C33 + Vision Shield: SD and QSPI
+* Opta: Internal QSPI Flash and USB
+

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The Arduino_UnifiedStorage library provides a unified interface to access differ
 2. Check compatibility with your platform
 3. To use internal storage, you need to make sure it is partitioned and formatted correctly:
 
-### Formatting the Portenta H7 Internal Storage
-* Flash the `QSPIFormat` example that can be found in the `STM32H747_System` folder (For Portenta H7/Opta/Giga)
+### Formatting the Portenta H7 / Portenta Machine Control / Opta Internal Storage
+* Flash the `QSPIFormat` example that can be found in the `STM32H747_System` folder
 * Open the serial monitor and select answer with "n" when this appears "Do you want to use partition scheme 1? Y/[n]"
 * The sketch will warn you that the content of the QSPI flash will be erased. Answer with "Y".
 * When asked if you'd like to use LittleFS on the data partition, select "n". Most of the examples assume that the drive is formatted as FAT. You can use the library to format to LittleFS later. 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ The Arduino_UnifiedStorage library provides a unified interface to access differ
 
 
 ## Examples
-* [**examples/SimpleStorageWriteRead**](https://github.com/arduino-libraries/Arduino_UnifiedStorage/blob/main/examples/SimpleStorageWriteRead/SimpleStorageWriteRead.ino) - this example is concerned with reading/writing and seeking
-* [**examples/AdvancedUSBInternalOperations**](https://github.com/arduino-libraries/Arduino_UnifiedStorage/blob/main/examples/AdvancedUSBInternalOperations/AdvancedUSBInternalOperations.ino) - this example is concerned with more advanced features like creating folders, traversing folder structures and moving/copying from one storage medium to another
-* [**examples/PortentaH7Logger**](https://github.com/arduino-libraries/Arduino_UnifiedStorage/blob/main/examples/PortentaH7Logger/PortentaH7Logger.ino) - this is more of a real life usecase, where this library is used to log sensor data to a file on the internal storage and check if a USB Mass Storage device is inserted. If it is detected it will backup the information on the internal storage, only copying the bytes that are new since the last update.
-* [**examples/BackupInternalPartitions**](https://github.com/arduino-libraries/Arduino_UnifiedStorage/blob/main/examples/BackupInternalPartitions/BackupInternalPartitions.ino) - Another real life usecase, where this library is used to back-up all partitions on the internal storage to a USB Mass Storage device.
+* [**examples/SimpleStorageWriteRead**](https://github.com/arduino-libraries/Arduino_UnifiedStorage/blob/main/examples/SimpleStorageWriteRead/SimpleStorageWriteRead.ino) - Write/read simple data from SD, USB and internal storage
+* [**examples/AdvancedUSBInternalOperations**](https://github.com/arduino-libraries/Arduino_UnifiedStorage/blob/main/examples/AdvancedUSBInternalOperations/AdvancedUSBInternalOperations.ino) - Navigate file structure and demonstrate file operations between USB and internal storage
+* [**examples/PortentaH7Logger**](https://github.com/arduino-libraries/Arduino_UnifiedStorage/blob/main/examples/PortentaH7Logger/PortentaH7Logger.ino) - Log analog input to the Portenta H7  with timestamp, then save to internal storage and backup to USB (if detected) 
+* [**examples/BackupInternalPartitions**](https://github.com/arduino-libraries/Arduino_UnifiedStorage/blob/main/examples/BackupInternalPartitions/BackupInternalPartitions.ino) - Back up all partitions on the internal storage to a USB Mass Storage device.
 
 ## Instructions
 1. Download and install this library 


### PR DESCRIPTION
To make the readme more applicable to users:
- 🔬 Reworded compatibility to say that it has been **tested** on the following STM32 and Renesas based Arduino boards. By reducing the scope to what has been tested, we can make users feel more confident. We can always increase the supported boards to include (for example) the Nicla Sense later.
https://github.com/arduino-libraries/Arduino_UnifiedStorage/blob/04d4dbb7de0b337d473157e5e3d020e54634f549/README.md?plain=1#L41-L42
- ➕ Added Opta to the list of compatible boards. The `complie-sketches` workflow does indeed compile for it, and we have tested on the physical Opta as well
https://github.com/arduino-libraries/Arduino_UnifiedStorage/blob/04d4dbb7de0b337d473157e5e3d020e54634f549/README.md?plain=1#L48
- 🔠 Shortened the descriptions for the examples in the read me. There is an extended description inside the `.ino` sketches for people who want more details.
https://github.com/arduino-libraries/Arduino_UnifiedStorage/blob/04d4dbb7de0b337d473157e5e3d020e54634f549/README.md?plain=1#L8-L12
@cristidragomir97 can you confirm the compatibility list is accurate?
