### PR TITLE
Update flag to make linter happy

### DIFF
--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -22,7 +22,7 @@ jobs:
         uses: arduino/arduino-lint-action@v1
         with:
           compliance: specification
-          library-manager: submit
+          library-manager: update
           # Always use this setting for official repositories. Remove for 3rd party projects.
           official: true
           project-type: library


### PR DESCRIPTION
The linter complains about the non-uniqueness of the library name because the current flag indicates that the lib is not yet in the registry. This PR changes that.