### PR TITLE
ci: remove libraries from `compile-examples.yml` workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -66,9 +66,6 @@ jobs:
           libraries: |
             # Install the library from the local path.
             - source-path: ./
-            - name: Arduino_USBHostMbed5
-            - name: Arduino_POSIXStorage
-            - name: ArduinoRS485
             # Additional library dependencies can be listed here.
             # See: https://github.com/arduino/compile-sketches#libraries
           sketch-paths: |

--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=With this versatile library, you can seamlessly handle various storage
 category=Data Storage
 url=https://github.com/arduino-libraries/Arduino_UnifiedStorage
 architectures=renesas_portenta,mbed_portenta,mbed_opta
-depends=Arduino_POSIXStorage,ArduinoRS485
+depends=Arduino_POSIXStorage,ArduinoRS485,Arduino_USBHostMbed5
 includes=Arduino_UnifiedStorage.h


### PR DESCRIPTION
This PR removes the explicit mention of the libraries in the workflow file.

https://github.com/arduino-libraries/Arduino_UnifiedStorage/blob/7739373d5aec30fb3929a0f06a29c7d0a2f30bc3/.github/workflows/compile-examples.yml#L69-L71

Following https://github.com/arduino-libraries/Arduino_UnifiedStorage/pull/29 and this PR all three dependancies are listed inside the library.properties file.