### PR TITLE
Ensure `prettyPrintFileSystemType()` returns correct spelling for LittleFS

### DIFF
--- a/src/Utils.h
+++ b/src/Utils.h
@@ -39,7 +39,7 @@
 
 [[gnu::unused]] static String prettyPrintFileSystemType(FileSystems f){
     if(f == 0) return "FAT";
-    else if(f == 1) return "LitlleFS";
+    else if(f == 1) return "LittleFS";
     else return "";
 }
 


### PR DESCRIPTION
Corrects spelling of LittleFS in the prettyPrintFileSystemType() method
Closes https://github.com/arduino-libraries/Arduino_UnifiedStorage/issues/43