### PR TITLE
Remove false claim of dirname parameter from Folder::remove doc comment

### DIFF
--- a/src/Folder.h
+++ b/src/Folder.h
@@ -52,7 +52,6 @@ class Folder {
 
     /**
      * @brief Removes a directory.
-     * @param dirname The name of the directory to remove.
      * @return True if the directory was removed successfully, false otherwise.
      */
     bool remove();


### PR DESCRIPTION
Previously the documentation comment claimed the function had a `dirname` parameter even though the function does not have any parameters.

This only fixes the comment, leaving the incorrect information in the API docs:

https://github.com/arduino-libraries/Arduino_UnifiedStorage/blob/7fd805e2bbafd2d55d53377edf5d7a5f26a281fe/docs/api.md?plain=1#L203-L212

That should be resolved by regenerating the documentation from the source code.

---

Originally reported at https://github.com/arduino-libraries/Arduino_UnifiedStorage/commit/f77f87312227805547c3e8603b53d170fb470224#r145141720