### PR TITLE
Set scope of enum values to enum class

### DIFF
--- a/src/Types.h
+++ b/src/Types.h
@@ -3,7 +3,7 @@
 
 #include "Boards.h"
 
-enum FileMode { READ, WRITE, APPEND };
+enum class FileMode { READ, WRITE, APPEND };
 
 #if defined(USES_RENESAS_CORE)
     #include "BlockDevice.h"

--- a/src/UFile.cpp
+++ b/src/UFile.cpp
@@ -21,13 +21,13 @@ bool UFile::open(const char* filename, FileMode fileMode) {
     path = filename;
     // Set the mode based on the fileMode
     switch (fileMode) {
-        case READ:
+        case FileMode::READ:
             mode = "r+";
             break;
-        case WRITE:
+        case FileMode::WRITE:
             mode = "w+";
             break;
-        case APPEND:
+        case FileMode::APPEND:
             mode = "a+";
             break;
         default:


### PR DESCRIPTION
Fixes #52. It does so by confining the scope of the enum values to the enum class. This would only break compatibility for boards using old toolchains, namely AVR boards which are not supported by this library anyway. I can't think of any side effects.