### PR TITLE
Add open function without path

### DIFF
--- a/src/UFile.cpp
+++ b/src/UFile.cpp
@@ -51,6 +51,15 @@ bool UFile::open(String filename, FileMode mode) {
     return open(filename.c_str(), mode);
 }
 
+bool UFile::open(FileMode mode) {
+    if (path.empty()) {
+        // Path is not set
+        return false;
+    }
+
+    return open(path.c_str(), mode);
+}
+
 void UFile::close() {
     // Close the file
     if (filePointer != nullptr) {

--- a/src/UFile.h
+++ b/src/UFile.h
@@ -52,6 +52,12 @@ public:
    */
   bool open(String filename, FileMode mode);
 
+  /**
+   * @brief Opens a file that was already initialized with a path.
+   * @param mode The file mode (READ, WRITE, or APPEND). The default is READ.
+   * @return True if the file was opened successfully, false otherwise.
+   */
+  bool open(FileMode mode = FileMode::READ);
 
   /**
    * @brief Closes the file and releases any allocated resources.


### PR DESCRIPTION
Currently, when creating a file with `createFile` the file is already open. However if we close the file and later want to re-open it, we'd need to provide the full file path which might be unknown at that moment. e.g.

```cpp
logFile = storage.getRootFolder().createFile("log.txt", FileMode::WRITE);
logFile.close();        
...
logFile.open("/usb/log.txt", FileMode::APPEND);
logFile.write(message);
```
This PR adds a function that re-uses the path set by `createFile` and `getRootFolder` respectively.