### PR TITLE
Fix broken compile sketches workflow

### DIFF
--- a/.github/workflows/compile-examples-profiles.yml
+++ b/.github/workflows/compile-examples-profiles.yml
@@ -47,16 +47,10 @@ jobs:
       matrix:
         board:
           - fqbn: arduino:mbed_portenta:envie_m7
-            platforms: |
-              - name: arduino:mbed_portenta
             artifact-name-suffix: arduino-mbed_portenta-envie_m7
           - fqbn: arduino:renesas_portenta:portenta_c33
-            platforms: |
-              - name: arduino:renesas_portenta
             artifact-name-suffix: arduino-renesas_portenta-portenta_c33
           - fqbn: arduino:mbed_opta:opta
-            platforms: |
-              - name: arduino:mbed_opta
             artifact-name-suffix: arduino-mbed_opta-opta
 
     steps:
@@ -67,12 +61,16 @@ jobs:
         uses: arduino/compile-sketches@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          cli-compile-flags: --profile ${{ matrix.board.fqbn }} 
           sketch-paths: |
             ${{ env.UNIVERSAL_SKETCH_PATHS }}
             ${{ matrix.board.additional-sketch-paths }}
+          fqbn: ${{ matrix.board.fqbn }}
+          cli-compile-flags: |
+            - --profile
+            - ${{ matrix.board.fqbn }}
           enable-deltas-report: true
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+          verbose: false
 
       - name: Save sketches report as workflow artifact
         uses: actions/upload-artifact@v4

--- a/examples/BackupInternalPartitions/sketch.yaml
+++ b/examples/BackupInternalPartitions/sketch.yaml
@@ -3,22 +3,21 @@ profiles:
     notes: Portenta H7 family & Portenta Machine Control
     fqbn: arduino:mbed_portenta:envie_m7
     platforms:
-      - platform: arduino:mbed_portenta (4.1.1)
+      - platform: arduino:mbed_portenta (4.4.1)
     libraries:
       - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root
   arduino:renesas_portenta:portenta_c33:
     notes: Portenta C33
     fqbn: arduino:renesas_portenta:portenta_c33
     platforms:
-      - platform: arduino:renesas_portenta (1.0.5)
+      - platform: arduino:renesas_portenta (1.5.0)
     libraries:
-      - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root
   arduino:mbed_opta:opta:
     notes: Portenta Opta family
     fqbn: arduino:mbed_opta:opta
@@ -26,6 +25,6 @@ profiles:
       - platform: arduino:mbed_opta (4.1.1)
     libraries:
       - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)  
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root

--- a/examples/Callbacks/sketch.yaml
+++ b/examples/Callbacks/sketch.yaml
@@ -3,22 +3,21 @@ profiles:
     notes: Portenta H7 family & Portenta Machine Control
     fqbn: arduino:mbed_portenta:envie_m7
     platforms:
-      - platform: arduino:mbed_portenta (4.1.1)
+      - platform: arduino:mbed_portenta (4.4.1)
     libraries:
       - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root
   arduino:renesas_portenta:portenta_c33:
     notes: Portenta C33
     fqbn: arduino:renesas_portenta:portenta_c33
     platforms:
-      - platform: arduino:renesas_portenta (1.0.5)
+      - platform: arduino:renesas_portenta (1.5.0)
     libraries:
-      - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root
   arduino:mbed_opta:opta:
     notes: Portenta Opta family
     fqbn: arduino:mbed_opta:opta
@@ -26,6 +25,6 @@ profiles:
       - platform: arduino:mbed_opta (4.1.1)
     libraries:
       - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)  
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root

--- a/examples/InternalStoragePartitioning/sketch.yaml
+++ b/examples/InternalStoragePartitioning/sketch.yaml
@@ -3,22 +3,21 @@ profiles:
     notes: Portenta H7 family & Portenta Machine Control
     fqbn: arduino:mbed_portenta:envie_m7
     platforms:
-      - platform: arduino:mbed_portenta (4.1.1)
+      - platform: arduino:mbed_portenta (4.4.1)
     libraries:
       - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root
   arduino:renesas_portenta:portenta_c33:
     notes: Portenta C33
     fqbn: arduino:renesas_portenta:portenta_c33
     platforms:
-      - platform: arduino:renesas_portenta (1.0.5)
+      - platform: arduino:renesas_portenta (1.5.0)
     libraries:
-      - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root
   arduino:mbed_opta:opta:
     notes: Portenta Opta family
     fqbn: arduino:mbed_opta:opta
@@ -26,6 +25,6 @@ profiles:
       - platform: arduino:mbed_opta (4.1.1)
     libraries:
       - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)  
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root

--- a/examples/Logger/sketch.yaml
+++ b/examples/Logger/sketch.yaml
@@ -3,22 +3,20 @@ profiles:
     notes: Portenta H7 family & Portenta Machine Control
     fqbn: arduino:mbed_portenta:envie_m7
     platforms:
-      - platform: arduino:mbed_portenta (4.1.1)
+      - platform: arduino:mbed_portenta (4.4.1)
     libraries:
       - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
   arduino:renesas_portenta:portenta_c33:
     notes: Portenta C33
     fqbn: arduino:renesas_portenta:portenta_c33
     platforms:
-      - platform: arduino:renesas_portenta (1.0.5)
+      - platform: arduino:renesas_portenta (1.5.0)
     libraries:
       - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
   arduino:mbed_opta:opta:
     notes: Portenta Opta family
     fqbn: arduino:mbed_opta:opta
@@ -26,6 +24,5 @@ profiles:
       - platform: arduino:mbed_opta (4.1.1)
     libraries:
       - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)  
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)

--- a/examples/Logger/sketch.yaml
+++ b/examples/Logger/sketch.yaml
@@ -8,6 +8,7 @@ profiles:
       - Arduino_USBHostMbed5 (0.3.1)
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root
   arduino:renesas_portenta:portenta_c33:
     notes: Portenta C33
     fqbn: arduino:renesas_portenta:portenta_c33
@@ -17,6 +18,7 @@ profiles:
       - Arduino_USBHostMbed5 (0.3.1)
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root
   arduino:mbed_opta:opta:
     notes: Portenta Opta family
     fqbn: arduino:mbed_opta:opta
@@ -26,3 +28,4 @@ profiles:
       - Arduino_USBHostMbed5 (0.3.1)
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root

--- a/examples/Logger/sketch.yaml
+++ b/examples/Logger/sketch.yaml
@@ -15,7 +15,6 @@ profiles:
     platforms:
       - platform: arduino:renesas_portenta (1.5.0)
     libraries:
-      - Arduino_USBHostMbed5 (0.3.1)
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
       - dir: ../../ # Relative path to the library root

--- a/examples/SimpleStorageWriteRead/sketch.yaml
+++ b/examples/SimpleStorageWriteRead/sketch.yaml
@@ -3,22 +3,21 @@ profiles:
     notes: Portenta H7 family & Portenta Machine Control
     fqbn: arduino:mbed_portenta:envie_m7
     platforms:
-      - platform: arduino:mbed_portenta (4.1.1)
+      - platform: arduino:mbed_portenta (4.4.1)
     libraries:
       - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root
   arduino:renesas_portenta:portenta_c33:
     notes: Portenta C33
     fqbn: arduino:renesas_portenta:portenta_c33
     platforms:
-      - platform: arduino:renesas_portenta (1.0.5)
+      - platform: arduino:renesas_portenta (1.5.0)
     libraries:
-      - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root
   arduino:mbed_opta:opta:
     notes: Portenta Opta family
     fqbn: arduino:mbed_opta:opta
@@ -26,6 +25,6 @@ profiles:
       - platform: arduino:mbed_opta (4.1.1)
     libraries:
       - Arduino_USBHostMbed5 (0.3.1)
-      - Arduino_POSIXStorage (1.2.0)
-      - Arduino_UnifiedStorage (1.1.0)
-      - ArduinoRS485 (1.0.5)  
+      - Arduino_POSIXStorage (1.2.1)
+      - ArduinoRS485 (1.1.0)
+      - dir: ../../ # Relative path to the library root

--- a/extras/tests/TestExisting/sketch.yaml
+++ b/extras/tests/TestExisting/sketch.yaml
@@ -8,7 +8,7 @@ profiles:
       - Arduino_USBHostMbed5 (0.3.1)
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
-      - dir: ../../ # Relative path to the library root
+      - dir: ../../../ # Relative path to the library root
   arduino:renesas_portenta:portenta_c33:
     notes: Portenta C33
     fqbn: arduino:renesas_portenta:portenta_c33
@@ -17,7 +17,7 @@ profiles:
     libraries:
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
-      - dir: ../../ # Relative path to the library root
+      - dir: ../../../ # Relative path to the library root
   arduino:mbed_opta:opta:
     notes: Portenta Opta family
     fqbn: arduino:mbed_opta:opta
@@ -27,4 +27,4 @@ profiles:
       - Arduino_USBHostMbed5 (0.3.1)
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
-      - dir: ../../ # Relative path to the library root
+      - dir: ../../../ # Relative path to the library root

--- a/extras/tests/TestFileOperations/sketch.yaml
+++ b/extras/tests/TestFileOperations/sketch.yaml
@@ -8,7 +8,7 @@ profiles:
       - Arduino_USBHostMbed5 (0.3.1)
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
-      - dir: ../../ # Relative path to the library root
+      - dir: ../../../ # Relative path to the library root
   arduino:renesas_portenta:portenta_c33:
     notes: Portenta C33
     fqbn: arduino:renesas_portenta:portenta_c33
@@ -17,7 +17,7 @@ profiles:
     libraries:
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
-      - dir: ../../ # Relative path to the library root
+      - dir: ../../../ # Relative path to the library root
   arduino:mbed_opta:opta:
     notes: Portenta Opta family
     fqbn: arduino:mbed_opta:opta
@@ -27,4 +27,4 @@ profiles:
       - Arduino_USBHostMbed5 (0.3.1)
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
-      - dir: ../../ # Relative path to the library root
+      - dir: ../../../ # Relative path to the library root

--- a/extras/tests/TestFolderOperations/sketch.yaml
+++ b/extras/tests/TestFolderOperations/sketch.yaml
@@ -8,7 +8,7 @@ profiles:
       - Arduino_USBHostMbed5 (0.3.1)
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
-      - dir: ../../ # Relative path to the library root
+      - dir: ../../../ # Relative path to the library root
   arduino:renesas_portenta:portenta_c33:
     notes: Portenta C33
     fqbn: arduino:renesas_portenta:portenta_c33
@@ -17,7 +17,7 @@ profiles:
     libraries:
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
-      - dir: ../../ # Relative path to the library root
+      - dir: ../../../ # Relative path to the library root
   arduino:mbed_opta:opta:
     notes: Portenta Opta family
     fqbn: arduino:mbed_opta:opta
@@ -27,4 +27,4 @@ profiles:
       - Arduino_USBHostMbed5 (0.3.1)
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
-      - dir: ../../ # Relative path to the library root
+      - dir: ../../../ # Relative path to the library root

--- a/extras/tests/TestRepeatedFormatMount/sketch.yaml
+++ b/extras/tests/TestRepeatedFormatMount/sketch.yaml
@@ -8,7 +8,7 @@ profiles:
       - Arduino_USBHostMbed5 (0.3.1)
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
-      - dir: ../../ # Relative path to the library root
+      - dir: ../../../ # Relative path to the library root
   arduino:renesas_portenta:portenta_c33:
     notes: Portenta C33
     fqbn: arduino:renesas_portenta:portenta_c33
@@ -17,7 +17,7 @@ profiles:
     libraries:
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
-      - dir: ../../ # Relative path to the library root
+      - dir: ../../../ # Relative path to the library root
   arduino:mbed_opta:opta:
     notes: Portenta Opta family
     fqbn: arduino:mbed_opta:opta
@@ -27,4 +27,4 @@ profiles:
       - Arduino_USBHostMbed5 (0.3.1)
       - Arduino_POSIXStorage (1.2.1)
       - ArduinoRS485 (1.1.0)
-      - dir: ../../ # Relative path to the library root
+      - dir: ../../../ # Relative path to the library root


### PR DESCRIPTION
This PR fixes the incorrect configuration of the workflow and the profiles. There were multiple issues:
- Incorrect usage of `cli-compile-flags`
- Missing local library path
- Unsupported library for Portenta C33 as dependency
- Missing sketch profile files