### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Arduino_UnifiedStorage
-version=1.1.2
+version=1.2.1
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Simplify cross-device storage management on Portenta platforms with a single library supporting SD, Flash, and USB storage access.


### PR DESCRIPTION
The actual v1.2.0 is not available on the library manager, the release target is 1.2.0 but the version value is 1.1.2

Once merged, create a new 1.2.1 target version to force the update on the library manager

Thanks